### PR TITLE
Revert 'go get' command to use gemalto instead of thalesgroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,11 @@ First, set up your environment:
 - If you don't have [Glide](http://glide.sh) installed, this will install it into
   `$GOPATH/bin` for you.
 
-Clone this repo into your `$GOPATH`. You can use `go get -d github.com/thalesgroup/helm-spray`
+Clone this repo into your `$GOPATH`. You can use `go get -d github.com/gemalto/helm-spray`
 for that.
 
 ```
-$ cd $GOPATH/src/github.com/thalesgroup/helm-spray
+$ cd $GOPATH/src/github.com/gemalto/helm-spray
 $ make dist_linux
 $ helm plugin install .
 ```


### PR DESCRIPTION
The go.mod file defines the module as `github.com/gemalto/helm-spray`. Changing Go module paths without making breaking changes is not supported (yet):
https://github.com/golang/go/issues/30831

Therefore this PR to revert to github.com/gemalto/helm-spray, as that still works as well.

Tests:
```bash
[root@centos8 git]# go get github.com/gemalto/helm-spray@master
go: downloading github.com/gemalto/helm-spray v0.0.0-20200317081907-8edada558592
go: github.com/gemalto/helm-spray master => v0.0.0-20200317081907-8edada558592
go: downloading k8s.io/helm v2.15.2+incompatible
go: downloading github.com/spf13/pflag v1.0.3
go: downloading k8s.io/apimachinery v0.0.0-20191025225532-af6325b3a843
go: downloading gopkg.in/yaml.v2 v2.2.4
[root@centos8 git]#
```

```bash
[root@centos8 git]# go get github.com/thalesgroup/helm-spray@master
go: downloading github.com/thalesgroup/helm-spray v0.0.0-20200317081907-8edada558592
go: github.com/thalesgroup/helm-spray master => v0.0.0-20200317081907-8edada558592
go get: github.com/thalesgroup/helm-spray@v0.0.0-20200317081907-8edada558592: parsing go.mod:
        module declares its path as: github.com/gemalto/helm-spray
                but was required as: github.com/thalesgroup/helm-spray
[root@centos8 git]#
```

An alternative could be to update the `go.mod` to use github.com/ThalesGroup/helm-spray. However, that'd be a breaking change and users need to be informed. The easiest solution would be correction the instructions in the README.

/cc @cvila84 @jroucheton 