### PR TITLE
Reapply PR #45 (lost in 3.4.6-rc) + Do not wait for StatefulSet when update strategy is OnDelete

### DIFF
--- a/main.go
+++ b/main.go
@@ -232,6 +232,9 @@ func (p *sprayCmd) spray() error {
 		// Load default values...
 		values, err = chartutil.CoalesceValues(chart, &chartHapi.Config{Raw: string(updatedDefaultValues)})
 		if err != nil {
+			if p.verbose {
+				logWithNumberedLines(1, updatedDefaultValues)
+			}
 			logErrorAndExit("Error processing default values for umbrella chart: %s", err)
 		}
 
@@ -773,12 +776,45 @@ func log(level int, str string, params ...interface{}) {
 		logStr = logStr + "        . "
 	}
 
-	fmt.Println(logStr + fmt.Sprintf(str, params...))
+	if len(params) != 0 {
+		fmt.Println(logStr + fmt.Sprintf(str, params...))
+	} else {
+		fmt.Println(logStr + str)
+	}
+}
+
+func logWithNumberedLines(level int, str string, params ...interface{}) {
+	// Number of lines to be printed
+	numberOfLines := strings.Count(str, "\n")
+    if len(str) > 0 && !strings.HasSuffix(str, "\n") {
+        numberOfLines++
+    }
+
+	// Compute the number of digits corresponding to this number of lines, so that the format of eachline is correct
+	numberOfDigits := 0
+	for numberOfLines != 0 {
+		numberOfLines /= 10
+		numberOfDigits = numberOfDigits + 1
+	}
+	format := "[%" + strconv.Itoa(numberOfDigits) + "d] %s"
+
+	// Print line by line
+	lineNbr := 0
+	scanner := bufio.NewScanner(strings.NewReader(str))
+	for scanner.Scan() {
+		log(level, fmt.Sprintf(format, lineNbr, scanner.Text()), params...)
+		lineNbr++
+	}
 }
 
 // Log error and exit
 func logErrorAndExit(str string, params ...interface{}) {
-	os.Stderr.WriteString(fmt.Sprintf(str + "\n", params...))
+	if len(params) != 0 {
+		os.Stderr.WriteString(fmt.Sprintf(str + "\n", params...))
+	} else {
+		os.Stderr.WriteString(str + "\n")
+	}
+
 	os.Exit(1)
 }
 

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -117,11 +117,6 @@ func IsJobCompleted(job string, namespace string) bool {
 // GetStatefulSetStrategy
 func GetStatefulSetStrategy(statefulset string, namespace string) string {
 	s := getObjectDescriptionItem("statefulset", statefulset, namespace, ".spec.updateStrategy.type")
-//	if len(s) >= 2 {
-//		if s[0] == `'` && s[len(s)-1] == `'` {
-//			return s[1 : len(s)-1]
-//		}
-//	}
 	return strings.Trim(s, "'")
 }
 

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -14,6 +14,7 @@ package kubectl
 
 import (
 	"fmt"
+	"strings"
 	"os"
 	"os/exec"
 )
@@ -88,10 +89,10 @@ func IsDeploymentUpToDate(deployment string, namespace string) bool {
 }
 
 // IsStatefulSetUpToDate ...
-func IsStatefulSetUpToDate(deployment string, namespace string) bool {
-	desired := getDesired("statefulset", deployment, namespace)
-	ready := getReady("statefulset", deployment, namespace)
-	current := getStatefulsetCurrent(deployment, namespace)
+func IsStatefulSetUpToDate(statefulset string, namespace string) bool {
+	desired := getDesired("statefulset", statefulset, namespace)
+	ready := getReady("statefulset", statefulset, namespace)
+	current := getStatefulsetCurrent(statefulset, namespace)
 	if desired != ready {
 		return false
 	} else {
@@ -113,6 +114,16 @@ func IsJobCompleted(job string, namespace string) bool {
 	}
 }
 
+// GetStatefulSetStrategy
+func GetStatefulSetStrategy(statefulset string, namespace string) string {
+	s := getObjectDescriptionItem("statefulset", statefulset, namespace, ".spec.updateStrategy.type")
+//	if len(s) >= 2 {
+//		if s[0] == `'` && s[len(s)-1] == `'` {
+//			return s[1 : len(s)-1]
+//		}
+//	}
+	return strings.Trim(s, "'")
+}
 
 // Utility functions to get informations extracted from a 'kubectl get' command result
 func getObjectDescriptionItem(k8sObjectType string, objectName string, namespace string, itemJsonPath string) string {


### PR DESCRIPTION
This PR targets version 3.x of Spray (i.e. Helm 2). It addresses the following:
- Re-introduce updates previously pushed in PR https://github.com/ThalesGroup/helm-spray/pull/45 but lost in the 3.4.6-rc releases that will never be issued.
- Do not wait for StatefulSet Pods re-deployment when StatefulSet update strategy is OnDelete (does not make any sense... and generate an infinite wait): addresses Issue https://github.com/ThalesGroup/helm-spray/issues/58

Both updates need to be forward-ported to version 4.x of Spray, i.e. for Helm 3 (subject to another PR).