### PR TITLE
Make scripts/install_plugin POSIX sh compliant

### DIFF
--- a/scripts/install_plugin.sh
+++ b/scripts/install_plugin.sh
@@ -6,9 +6,9 @@ os=$(uname)
 echo "Downloading and installing spray v${version} for ${os}..."
 
 url=""
-if [ "${os}" == "Linux" ] ; then
+if [ "${os}" = "Linux" ] ; then
     url="https://github.com/ThalesGroup/helm-spray/releases/download/v${version}/helm-spray-linux-amd64.tar.gz"
-elif [ "${os}" == "Darwin" ] ; then
+elif [ "${os}" = "Darwin" ] ; then
    url="https://github.com/ThalesGroup/helm-spray/releases/download/v${version}/helm-spray-darwin-amd64.tar.gz"
 else
     url="https://github.com/ThalesGroup/helm-spray/releases/download/v${version}/helm-spray-windows-amd64.tar.gz"
@@ -25,7 +25,7 @@ else
     wget -q "${url}" -O "releases/v${version}.tar.gz"
 fi
 tar xzf "releases/v${version}.tar.gz" -C "releases/v${version}"
-if [ "${os}" == "Linux" ] || [ "${os}" == "Darwin" ] ; then
+if [ "${os}" = "Linux" ] || [ "${os}" = "Darwin" ] ; then
     mv "releases/v${version}/bin/helm-spray" "bin/helm-spray"
 else
     mv "releases/v${version}/bin/helm-spray.exe" "bin/helm-spray.exe"


### PR DESCRIPTION
Hello, this PR makes the plugin's install script compliant with POSIX sh to improve compatibility.

This is inspired by https://github.com/chartmuseum/helm-push/commit/d065ec4eb27c1cb1a3459fa432301a6b226955f5

Fixes #71 